### PR TITLE
Revert "Bump tensorflow from 1.15 to 1.15.2 in /server"

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -4,7 +4,7 @@ py-cpuinfo
 #required for TPOD object detection
 Pillow
 tensorflow-object-detection-api==0.1.1
-tensorflow==1.15.2
+tensorflow==1.15
 #required for MS Face Cognitive Service
 azure-cognitiveservices-vision-face
 asyncio


### PR DESCRIPTION
Reverts cmusatyalab/openscout#5

tensorflow 1.15.2 no longer contains support for both GPU and CPU. Reverting so that we can support both with a single pip package.